### PR TITLE
Update Dockerfile, no need to run as root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Added
+
+*   Added GID and UID 2000 to Dockerfile. The `newrelic-istio-adapter` container now runs as non-root user. 
+
 ## 2.0.0
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,5 +39,10 @@ ARG GRPC_HEALTH_PROBE_VERSION=v0.2.0
 RUN wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 \
     && chmod +x /bin/grpc_health_probe
 
+# Create group and user, root privilege not needed
+RUN addgroup -g 2000 newrelic && \
+    adduser -S -D -H -u 2000 -G newrelic newrelic
+USER newrelic
+
 EXPOSE 55912
 ENTRYPOINT ["/go/bin/newrelic-istio-adapter"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health
 # Create group and user, root privilege not needed
 RUN addgroup -g 2000 newrelic && \
     adduser -S -D -H -u 2000 -G newrelic newrelic
-USER newrelic
+USER 2000
 
 EXPOSE 55912
 ENTRYPOINT ["/go/bin/newrelic-istio-adapter"]


### PR DESCRIPTION
The intent of this commit is to stop the newrelic-istio-adapter container from running as root.

The updates made are to create a group and user. Alpine is a little different:
```
# adduser -h
adduser: option requires an argument: h
BusyBox v1.30.1 (2019-06-12 17:51:55 UTC) multi-call binary.

Usage: adduser [OPTIONS] USER [GROUP]

Create new user, or add USER to GROUP

	-h DIR		Home directory
	-g GECOS	GECOS field
	-s SHELL	Login shell
	-G GRP		Group
	-S		Create a system user
	-D		Don't assign a password
	-H		Don't create home directory
	-u UID		User id
	-k SKEL		Skeleton directory (/etc/skel)

# addgroup
BusyBox v1.30.1 (2019-06-12 17:51:55 UTC) multi-call binary.

Usage: addgroup [-g GID] [-S] [USER] GROUP

Add a group or add a user to a group

	-g GID	Group id
	-S	Create a system group
```
This user will have no home, no password, and is a system user.

This [gist](https://gist.github.com/mpetruzelli/fa8d9d052d43ccd14b8ff4da307e2e8a) covers my testing setup.

There isn’t much guidance on which gid,uid to use for a pod/container, searching turns up [999](https://medium.com/@mccode/processes-in-containers-should-not-run-as-root-2feae3f0df3b), [1000](https://jtreminio.com/blog/running-docker-containers-as-current-host-user/#ok-so-what-actually-works), or 1001 as examples. But when setting these values it’s possible to “impersonate”, an existing user on the host. The only strategy/guidance I was able to find is rooted in [google cloud-init guidance](https://cloud.google.com/container-optimized-os/docs/how-to/create-configure-instance#using_cloud-init).

> This option explicitly sets the ID for the user and allows you to make sure the ID is consistent between different instances. It is recommended that you always set this option. Choose an ID from the [2000, 4999] range to avoid collision with other user accounts.

So bearing that in mind; uid,gid is set to 2000. Our user will be named `newrelic`.