### PR TITLE
Track release version by default instead of `latest`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 *   Added GID and UID 2000 to Dockerfile. The `newrelic-istio-adapter` container now runs as non-root user. 
 
+### Update
+
+*  Helm chart tracks a release tag instead of `latest`. This prevents any breaking change from the master branch from breaking installs of the adapter.
+*  Release version bump scripts keep the Docker image tag to install of the adapter to be current.
+
 ## 2.0.0
 
 ### Added

--- a/bin/bump_version.sh
+++ b/bin/bump_version.sh
@@ -23,6 +23,7 @@ readonly BIN_DIR="$( cd "$(dirname "$0")" ; pwd -P )"
 readonly VERSION_FILE="${BIN_DIR}/../VERSION"
 readonly CHANGELOG_FILE="${BIN_DIR}/../CHANGELOG.md"
 readonly HELM_CHART_MANIFEST="${BIN_DIR}/../helm-charts/Chart.yaml"
+readonly HELM_CHART_VALUES="${BIN_DIR}/../helm-charts/values.yaml"
 
 # Matches the expected semver spec: https://semver.org/
 readonly SEMVER_RE="^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(\\-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
@@ -77,6 +78,10 @@ main() {
     # Update app version in helm chart
     sed -i.bkup -e "/^appVersion.*/s/.*/appVersion: \"$version\"/" "$HELM_CHART_MANIFEST" \
         && rm "${HELM_CHART_MANIFEST}.bkup"
+
+    # Update the Docker image tag installed by Helm.
+    sed -i.bkup -e "/^  tag: .*/s/.*/  tag: \"$version\"/" "$HELM_CHART_VALUES" \
+        && rm "${HELM_CHART_VALUES}.bkup"
 
     # Update the project version file.
     echo "$version" > "$VERSION_FILE"

--- a/helm-charts/values.yaml
+++ b/helm-charts/values.yaml
@@ -69,7 +69,7 @@ image:
   # Repository for container image.
   repository: newrelic/newrelic-istio-adapter
   # Image tag.
-  tag: latest
+  tag: "2.0.0"
   # Image pull policy.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Update the Helm chart to install a tagged release of the adapter Docker image instead of the `latest` tag.

Update release management scripts to change Helm chart values to the bumped version.

Closes #11