### PR TITLE
Fix the default tracing rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+
+* The default tracing rule error for the incorrect parsed type in the rule expression is resolved. [#14](https://github.com/newrelic/newrelic-istio-adapter/issues/14)
+
 ## 2.0.1
 
 ### Added

--- a/helm-charts/values.yaml
+++ b/helm-charts/values.yaml
@@ -681,6 +681,6 @@ telemetry:
     ## The following can be uncommented if spans for inter-service communication
     ## should be sent to New Relic.
     #newrelic-tracing:
-    #  match: (context.protocol == "http" || context.protocol == "grpc") && destination.workload.name != "istio-telemetry" && destination.workload.name != "istio-pilot" && ((request.headers["x-b3-sampled"] | "0") == "1")
+    #  match: (context.protocol == "http" || context.protocol == "grpc") && destination.workload.name != "istio-telemetry" && destination.workload.name != "istio-pilot" && ((request.headers["x-b3-sampled"] | "") == "1")
     #  instances:
     #    - newrelic-span


### PR DESCRIPTION
The evaluation of the expression checking the B3 header interpreted the integer string as a duration instead of a string. Instead evaluate against an empty string as this will equivalently result in false if the header is not present.

Resolves #14