### PR TITLE
Update gRPC health check endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 * The default tracing rule error for the incorrect parsed type in the rule expression is resolved. [#14](https://github.com/newrelic/newrelic-istio-adapter/issues/14)
+* The gRPC health check endpoint is now specified to be targeted at `localhost` instead of just the port. [#16](https://github.com/newrelic/newrelic-istio-adapter/issues/16)
 
 ## 2.0.1
 

--- a/helm-charts/templates/deployment.yaml
+++ b/helm-charts/templates/deployment.yaml
@@ -68,11 +68,11 @@ spec:
             - $(NEW_RELIC_API_KEY)
           readinessProbe:
             exec:
-              command: ["/bin/grpc_health_probe", "-addr=:55912"]
+              command: ["/bin/grpc_health_probe", "-addr=localhost:55912"]
             initialDelaySeconds: 5
           livenessProbe:
             exec:
-              command: ["/bin/grpc_health_probe", "-addr=:55912"]
+              command: ["/bin/grpc_health_probe", "-addr=localhost:55912"]
             initialDelaySeconds: 10
           {{- with .Values.resources }}
           resources:


### PR DESCRIPTION
Specify `localhost` explicitly as the target host for the gRPC health checks.

Related to #16 