### PR TITLE
Add default codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for everything in the repo.
+*       @newrelic/oie

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 * Helm configuration to specify HTTP(S) proxies the adapter should use. [#16](https://github.com/newrelic/newrelic-istio-adapter/issues/16)
+* CODEOWNER file.
 
 ### Fixed
 


### PR DESCRIPTION
Makes the @newrelic/oie team default reviewers of the project.