### PR TITLE
Update travis build manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 kube/00-secret.yaml
 vendor*
 *newrelic-istio-adapter.yaml
+.snyk

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ install:
   - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then npm install -g snyk; fi
 
 script:
+  - snyk ignore --id=snyk:lic:golang:github.com:hashicorp:go-multierror:MPL-2.0 --reason='exemption given based on upstream inclusion'
+  - snyk ignore --id=snyk:lic:golang:github.com:hashicorp:errwrap:MPL-2.0 --reason='exemption given based on upstream inclusion'
   - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then if [ "$TRAVIS_BRANCH" = "master" ]; then cmd=monitor; else cmd=test; fi; snyk "$cmd"; fi
   - make lint
   - make test TAGS=integration

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,9 @@ env:
     - IMAGE_NAME=${DOCKER_REGISTRY_ID:-$DOCKER_USER}/newrelic-istio-adapter
 
 install:
-  - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then npm install -g snyk; fi
+  - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then npm install -g snyk; snyk ignore --id=snyk:lic:golang:github.com:hashicorp:go-multierror:MPL-2.0 --reason='exemption given based on upstream inclusion'; snyk ignore --id=snyk:lic:golang:github.com:hashicorp:errwrap:MPL-2.0 --reason='exemption given based on upstream inclusion'; fi
 
 script:
-  - snyk ignore --id=snyk:lic:golang:github.com:hashicorp:go-multierror:MPL-2.0 --reason='exemption given based on upstream inclusion'
-  - snyk ignore --id=snyk:lic:golang:github.com:hashicorp:errwrap:MPL-2.0 --reason='exemption given based on upstream inclusion'
   - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then if [ "$TRAVIS_BRANCH" = "master" ]; then cmd=monitor; else cmd=test; fi; snyk "$cmd"; fi
   - make lint
   - make test TAGS=integration


### PR DESCRIPTION
Add exemption for snyk failures on the MPL dependencies that have been deemed exempt. There exemption being derived from the fact that they are included in the upstream Istio code base and thus a requirement for this project to import as well.