### PR TITLE
Update deployment template

### DIFF
--- a/helm-charts/templates/deployment.yaml
+++ b/helm-charts/templates/deployment.yaml
@@ -45,17 +45,19 @@ spec:
             - name: grpc
               containerPort: 55912
           env:
-          {{- with .Values.proxy.https }}
+          {{- with .Values.proxy }}
+          {{- with .https }}
             - name: https_proxy
               value: {{ . }}
           {{- end }}
-          {{- with .Values.proxy.http }}
+          {{- with .http }}
             - name: http_proxy
               value: {{ . }}
           {{- end }}
-          {{- with .Values.proxy.none }}
+          {{- with .none }}
             - name: no_proxy
               value: {{ . }}
+          {{- end }}
           {{- end }}
             - name: NEW_RELIC_API_KEY
               valueFrom:

--- a/helm-charts/values.yaml
+++ b/helm-charts/values.yaml
@@ -94,7 +94,7 @@ tolerations: []
 # Kubernetes Deployment affinity definition.
 affinity: {}
 
-# HTTP(S) proxy settings.
+## HTTP(S) proxy settings.
 #proxy:
 #
 #  # HTTP proxy enpoint.


### PR DESCRIPTION
Break apart the proxy structure to its own scope. This allows proxy to not be defined (as the default values file defines it) and the template will still render without a nil pointer evaluation.

Fixes #26