### PR TITLE
Include a Snyk config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 kube/00-secret.yaml
 vendor*
 *newrelic-istio-adapter.yaml
-.snyk

--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,11 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.13.5
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  'snyk:lic:golang:github.com:hashicorp:go-multierror:MPL-2.0':
+    - '*':
+        reason: exemption given based on upstream inclusion
+  'snyk:lic:golang:github.com:hashicorp:errwrap:MPL-2.0':
+    - '*':
+        reason: exemption given based on upstream inclusion
+patch: {}

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,11 @@ env:
     - IMAGE_NAME=${DOCKER_REGISTRY_ID:-$DOCKER_USER}/newrelic-istio-adapter
 
 install:
-  - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then npm install -g snyk; snyk ignore --id=snyk:lic:golang:github.com:hashicorp:go-multierror:MPL-2.0 --reason='exemption given based on upstream inclusion'; snyk ignore --id=snyk:lic:golang:github.com:hashicorp:errwrap:MPL-2.0 --reason='exemption given based on upstream inclusion'; fi
+  - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then npm install -g snyk; fi
 
 script:
+  - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then snyk ignore --id=snyk:lic:golang:github.com:hashicorp:go-multierror:MPL-2.0 --reason='exemption given based on upstream inclusion'; fi
+  - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then snyk ignore --id=snyk:lic:golang:github.com:hashicorp:errwrap:MPL-2.0 --reason='exemption given based on upstream inclusion'; fi
   - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then if [ "$TRAVIS_BRANCH" = "master" ]; then cmd=monitor; else cmd=test; fi; snyk "$cmd"; fi
   - make lint
   - make test TAGS=integration

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,6 @@ install:
   - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then npm install -g snyk; fi
 
 script:
-  - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then snyk ignore --id=snyk:lic:golang:github.com:hashicorp:go-multierror:MPL-2.0 --reason='exemption given based on upstream inclusion'; fi
-  - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then snyk ignore --id=snyk:lic:golang:github.com:hashicorp:errwrap:MPL-2.0 --reason='exemption given based on upstream inclusion'; fi
   - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then if [ "$TRAVIS_BRANCH" = "master" ]; then cmd=monitor; else cmd=test; fi; snyk "$cmd"; fi
   - make lint
   - make test TAGS=integration


### PR DESCRIPTION
The snyk ignore command is not picking up auth creds in the CI system.
Transition to just including an unexpiring exemption in the snyk config.