### PR TITLE
Docs team edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,26 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/newrelic/newrelic-istio-adapter)](https://goreportcard.com/report/github.com/newrelic/newrelic-istio-adapter)
 [![Build Status](https://travis-ci.com/newrelic/newrelic-istio-adapter.svg?branch=master)](https://travis-ci.com/newrelic/newrelic-istio-adapter)
 
-# New Relic Istio Adapter
+# New Relic Istio adapter
 
 *An Istio Mixer adapter to send telemetry data to New Relic.*
 
-For more information on how Istio Mixer telemetry is created and collected, please see this [Mixer Overview](https://istio.io/docs/reference/config/policy-and-telemetry/mixer-overview/). 
+For more information on how Istio Mixer telemetry is created and collected, please see this [Mixer overview](https://istio.io/docs/reference/config/policy-and-telemetry/mixer-overview/). 
 
-For more information about out-of-process Istio Mixer adapters, please see the [Mixer Out of Process Adapter Walkthrough](https://github.com/istio/istio/wiki/Mixer-Out-Of-Process-Adapter-Walkthrough)
+For more information about out-of-process Istio Mixer adapters, please see the [Mixer out of process adapter walkthrough](https://github.com/istio/istio/wiki/Mixer-Out-Of-Process-Adapter-Walkthrough)
 
 ## Quotas
 
-**Metrics and Spans exported from this adapter to New Relic will be rate limited!**
+**Metrics and spans exported from this adapter to New Relic will be rate limited!**
 
 Currently (2019-08-30) the following quotas apply to APM Professional accounts:
 
 *   500,000 Metrics / minute
-    *   250,000 unique Metric timeseries
-    *   50 attributes per Metric
+    *   250,000 unique metric timeseries
+    *   50 attributes per metric
 *   5,000 Spans / minute
 
-You may request a quota increase for Metrics and/or Span by contacting your New Relic account representative.
+You may request a quota increase for metrics and/or spans by contacting your New Relic account representative.
 
 ## Quickstart
 
@@ -29,17 +29,17 @@ The `newrelic-istio-adapter` should be run alongside an installed/configured Ist
 For Kubernetes installations, Helm deployment charts have been provided in the `helm-charts` directory.
 These charts are intended to provide a simple installation and customization method for users.
 
-See the [Helm installation docs](https://helm.sh/docs/using_helm/#install-helm) for installation/configuration of Helm.
+See the [Helm install docs](https://helm.sh/docs/using_helm/#install-helm) for installation/configuration of Helm.
 
 ### Prerequisites
 
 *   A Kubernetes cluster
 *   A working `kubectl` installation
 *   A working `helm` installation
-*   A Healthy Istio deployment
-*   A New Relic Insights Insert API Key.
+*   A healthy Istio deployment
+*   A [New Relic Insights Insert API Key](https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#event-insert-key).
 
-### Deploy Helm Template
+### Deploy Helm template
 
 The `newrelic-istio-adapter` should be deployed to an independent namespace.
 This provides isolation and customizable access control.
@@ -118,8 +118,7 @@ newrelic-response-size        10s
 newrelic-span                 10s
 ```
 
-You should start to see metrics sent to [Insights](https://insights.newrelic.com) a few minutes after the deployment.
-As an example, this Insights query will display a timeseries graph of total Istio requests:
+You should be able to query your data via [NRQL](https://docs.newrelic.com/docs/query-data/nrql-new-relic-query-language/getting-started/introduction-nrql) within a few minutes of deployment. For example, this NRQL query will display a timeseries graph of total Istio requests:
 
 ```
 From Metric SELECT sum(istio.request.total) TIMESERIES
@@ -143,7 +142,7 @@ kubectl -n newrelic-istio-adapter logs -l app.kubernetes.io/name=newrelic-istio-
 
 To get started visualizing your data try the [sample dashboard template](#new-relic-dashboard-template).
 
-### Clean Up
+### Clean up
 
 If you want to remove the `newrelic-istio-adapter` you can do so by deleting the resources defined in the manifest you deployed.
 
@@ -151,7 +150,7 @@ If you want to remove the `newrelic-istio-adapter` you can do so by deleting the
 kubectl delete -f newrelic-istio-adapter.yaml
 ```
 
-## Distributed Tracing
+## Distributed tracing
 
 The `newrelic-istio-adapter` is able to send [trace spans from services within the Istio service mesh](https://istio.io/docs/tasks/telemetry/distributed-tracing/overview/) to New Relic.
 This functionality is disabled by default, but it can be enabled by adding the following `telemetry.rules` value when deploying the `newrelic-istio-adapter` Helm [chart](./helm-charts/README.md#configuration).
@@ -175,17 +174,15 @@ Additionally, the cost of sending spans to New Relic needs to be understood **be
 
 ## Find and use your data
 
-Once the adapter is sending data you can start to explore your data in New Relic:
-
-- Metric data: see [Metric API docs](https://docs.newrelic.com/docs/data-ingest-apis/get-data-new-relic/metric-api/introduction-metric-api#find-data).
-- Trace/span data: see [Trace API docs](https://docs.newrelic.com/docs/understand-dependencies/distributed-tracing/trace-api/introduction-trace-api#view-data).
+Tips on how to find and query your data in New Relic:
+- [Find metric data](https://docs.newrelic.com/docs/data-ingest-apis/get-data-new-relic/metric-api/introduction-metric-api#find-data)
+- [Find trace/span data](https://docs.newrelic.com/docs/understand-dependencies/distributed-tracing/trace-api/introduction-trace-api#view-data)
 
 For general querying information, see:
-
 - [Query New Relic data](https://docs.newrelic.com/docs/using-new-relic/data/understand-data/query-new-relic-data)
-- [Intro to NRQL](https://docs.newrelic.com/docs/query-data/nrql-new-relic-query-language/getting-started/nrql-syntax-clauses-functions)
+- [Intro to NRQL](https://docs.newrelic.com/docs/query-data/nrql-new-relic-query-language/getting-started/introduction-nrql)
 
-### New Relic Dashboard Template
+### New Relic dashboard template
 
 A [dashboard template](sample_newrelic_dashboard.json) is provided to chart some Istio metrics the default configuration produces. The template is designed to be imported with the [Insights Dashboard API](https://docs.newrelic.com/docs/insights/insights-api/manage-dashboards/insights-dashboard-api) and can be created straight from the [API Explorer](https://rpm.newrelic.com/api/explore/dashboards/create).
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For more information about out-of-process Istio Mixer adapters, please see the [
 
 Currently (2019-08-30) the following quotas apply to APM Professional accounts:
 
-*   500,000 Metrics / minute
+*   500,000 metrics / minute
     *   250,000 unique metric timeseries
     *   50 attributes per metric
 *   5,000 Spans / minute


### PR DESCRIPTION
This is from Zach Elwood on NR docs team. 

This PR is to add a ‘how to find data’ section so that customers can find the data they send. I’ve included what I think are the applicable data types (spans and metrics) but let me know if there are other data types reported by this exporter. If you think this exporter will change to send other types of data in future, keep in mind it will be important to update this repo with link to that data type.

Also changed some instances of title case to sentence case; small thing but we want headings to be sentence case and not title case, so just something to keep in mind when creating new content. Let me know if you think I changed sentence case stuff that shouldn't have been changed. 

Also changed from 'Use Insights' to 'Use NRQL'. We want to avoid instances of Insights because we want to promote NR1 chart builder, or just mention NRQL for specific NRQL use cases. 